### PR TITLE
hive: add option to persistently disallow substitutes

### DIFF
--- a/src/command/apply.rs
+++ b/src/command/apply.rs
@@ -181,12 +181,15 @@ pub async fn run(hive: Hive, opts: Opts) -> Result<(), ColmenaError> {
     // FIXME: Configure limits
     let options = {
         let mut options = Options::default();
-        options.set_substituters_push(!no_substitute);
         options.set_gzip(!no_gzip);
         options.set_upload_keys(!no_keys);
         options.set_reboot(reboot);
         options.set_force_replace_unknown_profiles(force_replace_unknown_profiles);
         options.set_evaluator(evaluator);
+
+        if no_substitute {
+            options.set_substituters_push(!no_substitute);
+        }
 
         if keep_result {
             options.set_create_gc_roots(true);

--- a/src/command/apply.rs
+++ b/src/command/apply.rs
@@ -62,8 +62,15 @@ pub struct DeployOpts {
     /// Do not use substitutes
     ///
     /// Disables the use of substituters when copying closures to the remote host.
-    #[arg(long)]
+    #[arg(long, overrides_with = "use_substitute")]
     no_substitutes: bool,
+
+    /// Use substitutes
+    ///
+    /// Enables the use of substituters when copying closures to the remote host. This flag
+    /// can be used to override the per-node `deployment.noSubstitutes` option.
+    #[arg(long, alias = "use-substitutes")]
+    use_substitute: bool,
 
     /// Do not use gzip
     ///
@@ -144,6 +151,7 @@ pub async fn run(hive: Hive, opts: Opts) -> Result<(), ColmenaError> {
                 no_keys,
                 reboot,
                 no_substitutes,
+                use_substitute,
                 no_gzip,
                 build_on_target,
                 no_build_on_target,
@@ -189,6 +197,8 @@ pub async fn run(hive: Hive, opts: Opts) -> Result<(), ColmenaError> {
 
         if no_substitutes {
             options.set_substituters_push(!no_substitutes);
+        } else if use_substitute {
+            options.set_substituters_push(use_substitute);
         }
 
         if keep_result {

--- a/src/command/apply.rs
+++ b/src/command/apply.rs
@@ -62,8 +62,8 @@ pub struct DeployOpts {
     /// Do not use substitutes
     ///
     /// Disables the use of substituters when copying closures to the remote host.
-    #[arg(long, alias = "no-substitutes")]
-    no_substitute: bool,
+    #[arg(long)]
+    no_substitutes: bool,
 
     /// Do not use gzip
     ///
@@ -143,7 +143,7 @@ pub async fn run(hive: Hive, opts: Opts) -> Result<(), ColmenaError> {
                 verbose,
                 no_keys,
                 reboot,
-                no_substitute,
+                no_substitutes,
                 no_gzip,
                 build_on_target,
                 no_build_on_target,
@@ -187,8 +187,8 @@ pub async fn run(hive: Hive, opts: Opts) -> Result<(), ColmenaError> {
         options.set_force_replace_unknown_profiles(force_replace_unknown_profiles);
         options.set_evaluator(evaluator);
 
-        if no_substitute {
-            options.set_substituters_push(!no_substitute);
+        if no_substitutes {
+            options.set_substituters_push(!no_substitutes);
         }
 
         if keep_result {

--- a/src/nix/deployment/options.rs
+++ b/src/nix/deployment/options.rs
@@ -8,7 +8,7 @@ use crate::nix::CopyOptions;
 #[derive(Clone, Debug)]
 pub struct Options {
     /// Whether to use binary caches when copying closures to remote hosts.
-    pub(super) substituters_push: bool,
+    pub(super) substituters_push: Option<bool>,
 
     /// Whether to use gzip when copying closures to remote hosts.
     pub(super) gzip: bool,
@@ -54,7 +54,7 @@ impl std::fmt::Display for EvaluatorType {
 
 impl Options {
     pub fn set_substituters_push(&mut self, value: bool) {
-        self.substituters_push = value;
+        self.substituters_push = Some(value);
     }
 
     pub fn set_gzip(&mut self, value: bool) {
@@ -87,17 +87,18 @@ impl Options {
 
     pub fn to_copy_options(&self) -> CopyOptions {
         let options = CopyOptions::default();
-
-        options
-            .use_substitutes(self.substituters_push)
-            .gzip(self.gzip)
+        let options = match self.substituters_push {
+            Some(val) => options.use_substitutes(val),
+            _ => options,
+        };
+        options.gzip(self.gzip)
     }
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
-            substituters_push: true,
+            substituters_push: None,
             gzip: true,
             upload_keys: true,
             reboot: false,

--- a/src/nix/hive/options.nix
+++ b/src/nix/hive/options.nix
@@ -178,6 +178,15 @@ rec {
             type = types.bool;
             default = false;
           };
+          noSubstitutes = lib.mkOption {
+            description = ''
+              Disables the use of substituters when copying closures to the
+              remote host. This option can be useful to deploy to nodes that do
+              not have an internet connection.
+            '';
+            type = types.bool;
+            default = false;
+          };
           tags = lib.mkOption {
             description = ''
               A list of tags for the node.

--- a/src/nix/host/mod.rs
+++ b/src/nix/host/mod.rs
@@ -23,7 +23,7 @@ pub enum CopyDirection {
 #[derive(Copy, Clone, Debug)]
 pub struct CopyOptions {
     include_outputs: bool,
-    use_substitutes: bool,
+    use_substitutes: Option<bool>,
     gzip: bool,
 }
 
@@ -40,7 +40,7 @@ impl Default for CopyOptions {
     fn default() -> Self {
         Self {
             include_outputs: true,
-            use_substitutes: true,
+            use_substitutes: None,
             gzip: true,
         }
     }
@@ -53,7 +53,7 @@ impl CopyOptions {
     }
 
     pub fn use_substitutes(mut self, val: bool) -> Self {
-        self.use_substitutes = val;
+        self.use_substitutes = Some(val);
         self
     }
 

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -278,13 +278,16 @@ impl Ssh {
                 "--no-check-sigs",
             ]);
 
-            if options.use_substitutes {
-                command.args([
-                    "--substitute-on-destination",
-                    // needed due to UX bug in ssh-ng://
-                    "--builders-use-substitutes",
-                ]);
-            }
+            match options.use_substitutes {
+                None | Some(true) => {
+                    command.args([
+                        "--substitute-on-destination",
+                        // needed due to UX bug in ssh-ng://
+                        "--builders-use-substitutes",
+                    ]);
+                }
+                Some(false) => {}
+            };
 
             if let Some("drv") = path.extension().and_then(OsStr::to_str) {
                 command.arg("--derivation");
@@ -325,9 +328,14 @@ impl Ssh {
             if options.include_outputs {
                 command.arg("--include-outputs");
             }
-            if options.use_substitutes {
-                command.arg("--use-substitutes");
-            }
+
+            match options.use_substitutes {
+                None | Some(true) => {
+                    command.arg("--use-substitutes");
+                }
+                Some(false) => {}
+            };
+
             if options.gzip {
                 command.arg("--gzip");
             }

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -70,6 +70,9 @@ pub struct NodeConfig {
     #[serde(rename = "buildOnTarget")]
     build_on_target: bool,
 
+    #[serde(rename = "noSubstitutes")]
+    no_substitutes: bool,
+
     tags: Vec<String>,
 
     #[serde(rename = "replaceUnknownProfiles")]
@@ -186,6 +189,7 @@ impl NodeConfig {
             let mut host = Ssh::new(self.target_user.clone(), target_host.clone());
             host.set_privilege_escalation_command(self.privilege_escalation_command.clone());
             host.set_extra_ssh_options(self.extra_ssh_options.clone());
+            host.set_use_substitutes(!self.no_substitutes);
 
             if let Some(target_port) = self.target_port {
                 host.set_port(target_port);

--- a/src/nix/node_filter.rs
+++ b/src/nix/node_filter.rs
@@ -243,6 +243,7 @@ mod tests {
             target_port: None,
             allow_local_deployment: false,
             build_on_target: false,
+            no_substitutes: false,
             replace_unknown_profiles: false,
             privilege_escalation_command: vec![],
             extra_ssh_options: vec![],


### PR DESCRIPTION
While Colmena provides a "--no-substitutes" flag to disable substitutes,
there is no way to persistently disable their use. Such an option would
be useful though in cases where one is deploying to a node that does not
have an internet connection, which would otherwise fail if the flag was
not given.

Introduce a new per-node "deployment.noSubstitute" option that allows
you to persistently disable the use of substitutes. This option defaults
to "false", which is in line with the current default. Furthermore, the
option gets overridden by the "--no-substitutes" command line flag.

Part of #187.