### PR TITLE
Fix repl in presence of additional experimental features

### DIFF
--- a/src/command/repl.rs
+++ b/src/command/repl.rs
@@ -27,7 +27,7 @@ pub async fn run(hive: Hive) -> ColmenaResult<()> {
     if nix_version.at_least(2, 4) {
         // `nix repl` is expected to be marked as experimental:
         // <https://github.com/NixOS/nix/issues/5604>
-        repl_cmd.args(["--experimental-features", "nix-command flakes"]);
+        repl_cmd.args(["--extra-experimental-features", "nix-command flakes"]);
     }
 
     if nix_version.at_least(2, 10) {


### PR DESCRIPTION
All the other places which shell out to `nix` add their required features using `--extra-experimental-features`, this PR brings the `nix repl` invocation in line with them and makes sure that `colmena repl` can work with a configuration which requires more experimental features than just `nix-command` and `flakes`, for example `pipe-operator` (which is why i've noticed).