### PR TITLE
treewide: drop legacy code paths and refactor how CLI flags are passed

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -329,28 +329,28 @@ pub async fn run() {
     use crate::troubleshooter::run_wrapped as r;
 
     match opts.command {
-        Command::Apply(args) => r(command::apply::run(hive, args), opts.config).await,
+        Command::Apply(args) => r(command::apply::run(hive, args)).await,
         #[cfg(target_os = "linux")]
-        Command::ApplyLocal(args) => r(command::apply_local::run(hive, args), opts.config).await,
-        Command::Eval(args) => r(command::eval::run(hive, args), opts.config).await,
-        Command::Exec(args) => r(command::exec::run(hive, args), opts.config).await,
-        Command::NixInfo => r(command::nix_info::run(), opts.config).await,
-        Command::Repl => r(command::repl::run(hive), opts.config).await,
+        Command::ApplyLocal(args) => r(command::apply_local::run(hive, args)).await,
+        Command::Eval(args) => r(command::eval::run(hive, args)).await,
+        Command::Exec(args) => r(command::exec::run(hive, args)).await,
+        Command::NixInfo => r(command::nix_info::run()).await,
+        Command::Repl => r(command::repl::run(hive)).await,
         #[cfg(debug_assertions)]
-        Command::TestProgress => r(command::test_progress::run(), opts.config).await,
+        Command::TestProgress => r(command::test_progress::run()).await,
         Command::Build { deploy } => {
             let args = command::apply::Opts {
                 deploy,
                 goal: crate::nix::Goal::Build,
             };
-            r(command::apply::run(hive, args), opts.config).await
+            r(command::apply::run(hive, args)).await
         }
         Command::UploadKeys { deploy } => {
             let args = command::apply::Opts {
                 deploy,
                 goal: crate::nix::Goal::UploadKeys,
             };
-            r(command::apply::run(hive, args), opts.config).await
+            r(command::apply::run(hive, args)).await
         }
         Command::GenCompletions { .. } => unreachable!(),
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::EnvFilter;
 use crate::{
     command::{self, apply::DeployOpts},
     error::{ColmenaError, ColmenaResult},
-    nix::{Hive, HivePath, hive::EvaluationMethod},
+    nix::{Hive, HivePath, NixFlags, hive::EvaluationMethod},
 };
 
 /// Base URL of the manual, without the trailing slash.
@@ -112,7 +112,7 @@ struct Opts {
         display_order = HELP_ORDER_FIRST,
         global = true,
     )]
-    config: Option<HivePath>,
+    config: Option<String>,
 
     /// Show debug information for Nix commands
     ///
@@ -128,7 +128,9 @@ struct Opts {
 
     /// Passes an arbitrary option to Nix commands
     ///
-    /// This only works when building locally.
+    /// The option applies to all Nix invocations made by Colmena (local and remote).
+    /// Values referring to local paths (e.g., extra-builtins-file) are also passed to
+    /// deployment targets, where those paths may not exist.
     #[arg(
         long,
         global = true,
@@ -222,9 +224,39 @@ enum Command {
     },
 }
 
-async fn get_hive(opts: &Opts) -> ColmenaResult<Hive> {
-    let path = match &opts.config {
-        Some(path) => path.clone(),
+/// Builds Nix flags from CLI options.
+///
+/// This derives CLI flags for all Nix invocations.
+fn get_nix_flags(opts: &Opts) -> NixFlags {
+    let mut flags = NixFlags::default();
+    flags.set_show_trace(opts.show_trace);
+    flags.set_impure(opts.impure);
+
+    for chunks in opts.nix_option.chunks_exact(2) {
+        let [name, value] = chunks else {
+            unreachable!()
+        };
+        flags.add_option(name.clone(), value.clone());
+    }
+
+    flags
+}
+
+/// Resolves the configured HivePath, if -f/--config was given.
+async fn get_config_path(opts: &Opts, flags: &NixFlags) -> ColmenaResult<Option<HivePath>> {
+    match &opts.config {
+        Some(config) => Ok(Some(HivePath::resolve(config, flags).await?)),
+        None => Ok(None),
+    }
+}
+
+async fn get_hive(
+    opts: &Opts,
+    config_path: Option<HivePath>,
+    flags: NixFlags,
+) -> ColmenaResult<Hive> {
+    let path = match config_path {
+        Some(path) => path,
         None => {
             // traverse upwards until we find hive.nix
             let mut cur = std::env::current_dir()?;
@@ -260,7 +292,7 @@ async fn get_hive(opts: &Opts) -> ColmenaResult<Hive> {
                 );
             }
 
-            HivePath::from_path(file_path.unwrap()).await?
+            HivePath::from_path(file_path.unwrap(), &flags).await?
         }
     };
 
@@ -273,15 +305,7 @@ async fn get_hive(opts: &Opts) -> ColmenaResult<Hive> {
         }
     }
 
-    let mut hive = Hive::new(path).await?;
-
-    if opts.show_trace {
-        hive.set_show_trace(true);
-    }
-
-    if opts.impure {
-        hive.set_impure(true);
-    }
+    let mut hive = Hive::new(path, flags).await?;
 
     if opts.deprecated_experimental_flake_eval_flag {
         tracing::error!(
@@ -303,13 +327,6 @@ async fn get_hive(opts: &Opts) -> ColmenaResult<Hive> {
         hive.set_evaluation_method(EvaluationMethod::NixInstantiate);
     }
 
-    for chunks in opts.nix_option.chunks_exact(2) {
-        let [name, value] = chunks else {
-            unreachable!()
-        };
-        hive.add_nix_option(name.clone(), value.clone());
-    }
-
     Ok(hive)
 }
 
@@ -324,7 +341,27 @@ pub async fn run() {
         return;
     }
 
-    let hive = get_hive(&opts).await.expect("Failed to get flake or hive");
+    let flags = get_nix_flags(&opts);
+
+    let config_path = match get_config_path(&opts, &flags).await {
+        Ok(config_path) => config_path,
+        Err(error) => {
+            tracing::error!(
+                "Failed to resolve configuration \"{}\": {}",
+                opts.config.as_deref().unwrap_or_default(),
+                error
+            );
+            quit::with_code(2);
+        }
+    };
+
+    let hive = match get_hive(&opts, config_path, flags.clone()).await {
+        Ok(hive) => hive,
+        Err(error) => {
+            tracing::error!("Failed to load the hive: {}", error);
+            quit::with_code(2);
+        }
+    };
 
     use crate::troubleshooter::run_wrapped as r;
 
@@ -334,7 +371,7 @@ pub async fn run() {
         Command::ApplyLocal(args) => r(command::apply_local::run(hive, args)).await,
         Command::Eval(args) => r(command::eval::run(hive, args)).await,
         Command::Exec(args) => r(command::exec::run(hive, args)).await,
-        Command::NixInfo => r(command::nix_info::run()).await,
+        Command::NixInfo => r(command::nix_info::run(flags)).await,
         Command::Repl => r(command::repl::run(hive)).await,
         #[cfg(debug_assertions)]
         Command::TestProgress => r(command::test_progress::run()).await,

--- a/src/command/apply_local.rs
+++ b/src/command/apply_local.rs
@@ -97,7 +97,7 @@ pub async fn run(
 
     let target = {
         if let Some(info) = hive.deployment_info_single(&hostname).await.unwrap() {
-            let nix_options = hive.nix_flags_with_builders().await.unwrap();
+            let nix_flags = hive.nix_flags_with_builders().await.unwrap();
             if !info.allows_local_deployment() {
                 tracing::error!(
                     "Local deployment is not enabled for host {}.",
@@ -106,7 +106,7 @@ pub async fn run(
                 tracing::error!("Hint: Set deployment.allowLocalDeployment to true.");
                 quit::with_code(2);
             }
-            let mut host = LocalHost::new(nix_options);
+            let mut host = LocalHost::new(nix_flags);
             if sudo {
                 let command = info.privilege_escalation_command().to_owned();
                 host.set_privilege_escalation_command(Some(command));

--- a/src/command/nix_info.rs
+++ b/src/command/nix_info.rs
@@ -1,9 +1,9 @@
 use crate::error::ColmenaResult;
-use crate::nix::NixCheck;
 use crate::nix::evaluator::nix_eval_jobs::get_pinned_nix_eval_jobs;
+use crate::nix::{NixCheck, NixFlags};
 
-pub async fn run() -> ColmenaResult<()> {
-    let check = NixCheck::detect().await;
+pub async fn run(flags: NixFlags) -> ColmenaResult<()> {
+    let check = NixCheck::detect(&flags).await;
     check.print_version_info();
     check.print_flakes_info();
 

--- a/src/command/nix_info.rs
+++ b/src/command/nix_info.rs
@@ -5,7 +5,7 @@ use crate::nix::evaluator::nix_eval_jobs::get_pinned_nix_eval_jobs;
 pub async fn run() -> ColmenaResult<()> {
     let check = NixCheck::detect().await;
     check.print_version_info();
-    check.print_flakes_info(false);
+    check.print_flakes_info();
 
     if let Some(pinned) = get_pinned_nix_eval_jobs() {
         tracing::info!("Using pinned nix-eval-jobs: {}", pinned);

--- a/src/command/repl.rs
+++ b/src/command/repl.rs
@@ -5,12 +5,8 @@ use tokio::process::Command;
 
 use crate::error::ColmenaResult;
 use crate::nix::Hive;
-use crate::nix::info::NixCheck;
 
 pub async fn run(hive: Hive) -> ColmenaResult<()> {
-    let nix_check = NixCheck::detect().await;
-    let nix_version = nix_check.version().expect("Could not detect Nix version");
-
     let expr = hive.get_repl_expression();
 
     let mut expr_file = TempFileBuilder::new()
@@ -24,15 +20,10 @@ pub async fn run(hive: Hive) -> ColmenaResult<()> {
 
     repl_cmd.arg("repl");
 
-    if nix_version.at_least(2, 4) {
-        // `nix repl` is expected to be marked as experimental:
-        // <https://github.com/NixOS/nix/issues/5604>
-        repl_cmd.args(["--experimental-features", "nix-command flakes"]);
-    }
-
-    if nix_version.at_least(2, 10) {
-        repl_cmd.arg("--file");
-    }
+    // `nix repl` is expected to be marked as experimental:
+    // <https://github.com/NixOS/nix/issues/5604>
+    repl_cmd.args(["--experimental-features", "nix-command flakes"]);
+    repl_cmd.arg("--file");
 
     let status = repl_cmd.arg(expr_file.path()).status().await?;
 

--- a/src/command/repl.rs
+++ b/src/command/repl.rs
@@ -1,12 +1,16 @@
 use std::io::Write;
 
 use tempfile::Builder as TempFileBuilder;
-use tokio::process::Command;
 
 use crate::error::ColmenaResult;
-use crate::nix::Hive;
+use crate::nix::{Hive, NixCommand};
 
 pub async fn run(hive: Hive) -> ColmenaResult<()> {
+    let mut flags = hive.nix_flags();
+
+    // `nix repl --file` is incompatible with --pure-eval
+    flags.set_pure_eval(false);
+
     let expr = hive.get_repl_expression();
 
     let mut expr_file = TempFileBuilder::new()
@@ -16,16 +20,13 @@ pub async fn run(hive: Hive) -> ColmenaResult<()> {
 
     expr_file.write_all(expr.as_bytes())?;
 
-    let mut repl_cmd = Command::new("nix");
-
-    repl_cmd.arg("repl");
-
-    // `nix repl` is expected to be marked as experimental:
-    // <https://github.com/NixOS/nix/issues/5604>
-    repl_cmd.args(["--experimental-features", "nix-command flakes"]);
-    repl_cmd.arg("--file");
-
-    let status = repl_cmd.arg(expr_file.path()).status().await?;
+    let status = NixCommand::nix(flags)
+        .arg("repl")
+        .arg("--file")
+        .arg(expr_file.path())
+        .build()
+        .status()
+        .await?;
 
     if !status.success() {
         return Err(status.into());

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,9 +58,6 @@ pub enum ColmenaError {
     #[snafu(display("Could not determine current profile"))]
     FailedToGetCurrentProfile,
 
-    #[snafu(display("Current Nix version does not support Flakes"))]
-    NoFlakesSupport,
-
     #[snafu(display("Don't know how to connect to the node"))]
     NoTargetHost,
 

--- a/src/nix/command.rs
+++ b/src/nix/command.rs
@@ -1,0 +1,391 @@
+//! Nix command builder.
+//!
+//! All invocations of Nix related binaries in Colmena go through [`NixCommand`],
+//! which projects a single set of [`NixFlags`] onto each binary according to
+//! what that binary actually accepts (see [`NixExe::caps`]).
+
+use std::borrow::Cow;
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+use tokio::process::Command;
+
+use super::NixFlags;
+
+/// A Nix executable.
+#[derive(Debug, Clone)]
+enum NixExe {
+    /// The nix3 CLI (`nix eval`, `nix copy`, `nix flake`, `nix repl`, ...).
+    Nix,
+    NixInstantiate,
+    NixStore,
+    NixEnv,
+    NixCopyClosure,
+    /// `nix-eval-jobs`, possibly at a pinned path.
+    NixEvalJobs(PathBuf),
+}
+
+/// The flags accepted by a Nix executable.
+struct Caps {
+    /// Whether `--option NAME VALUE` is accepted.
+    options: bool,
+
+    /// Whether `--show-trace` is accepted.
+    show_trace: bool,
+
+    /// Whether `--pure-eval` is accepted.
+    ///
+    /// `pure-eval` is a Nix setting, and the legacy binaries accept
+    /// setting flags even when they do not evaluate anything.
+    pure_eval: bool,
+
+    /// Whether `--impure` is accepted.
+    ///
+    /// Unlike `--pure-eval`, `--impure` is not a setting but an
+    /// evaluator flag: `nix-store` rejects it and `nix-copy-closure`
+    /// misparses it as a positional argument. `nix-env --set` performs
+    /// no evaluation, so the flag is conservatively omitted there
+    /// as well (acceptance varies across Nix versions).
+    impure: bool,
+
+    /// Experimental features to enable by default via
+    /// `--extra-experimental-features`.
+    features: &'static [&'static str],
+}
+
+impl NixExe {
+    fn executable(&self) -> Cow<'static, OsStr> {
+        match self {
+            Self::Nix => OsStr::new("nix").into(),
+            Self::NixInstantiate => OsStr::new("nix-instantiate").into(),
+            Self::NixStore => OsStr::new("nix-store").into(),
+            Self::NixEnv => OsStr::new("nix-env").into(),
+            Self::NixCopyClosure => OsStr::new("nix-copy-closure").into(),
+            Self::NixEvalJobs(path) => path.clone().into_os_string().into(),
+        }
+    }
+
+    fn caps(&self) -> Caps {
+        match self {
+            Self::Nix => Caps {
+                options: true,
+                show_trace: true,
+                pure_eval: true,
+                impure: true,
+                features: &["nix-command", "flakes"],
+            },
+            Self::NixInstantiate => Caps {
+                options: true,
+                show_trace: true,
+                pure_eval: true,
+                impure: true,
+                // The "flakes" feature is only needed with `builtins.getFlake`
+                // and is enabled by call sites when evaluating a flake.
+                features: &[],
+            },
+            Self::NixStore | Self::NixEnv | Self::NixCopyClosure => Caps {
+                options: true,
+                show_trace: true,
+                pure_eval: true,
+                impure: false,
+                features: &[],
+            },
+            Self::NixEvalJobs(_) => Caps {
+                options: true,
+                show_trace: true,
+                pure_eval: true,
+                impure: true,
+                features: &[],
+            },
+        }
+    }
+}
+
+/// A builder for a Nix command invocation.
+///
+/// The builder holds a shared set of [`NixFlags`] and only emits the
+/// flags the target executable accepts, so the same flags can be
+/// threaded into every Nix invocation regardless of CLI dialect.
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct NixCommand {
+    exe: NixExe,
+    flags: NixFlags,
+    extra_features: Vec<&'static str>,
+    args: Vec<OsString>,
+}
+
+impl NixCommand {
+    /// Creates an invocation of the nix3 CLI (`nix`).
+    pub fn nix(flags: NixFlags) -> Self {
+        Self::new(NixExe::Nix, flags)
+    }
+
+    /// Creates an invocation of `nix-instantiate`.
+    pub fn nix_instantiate(flags: NixFlags) -> Self {
+        Self::new(NixExe::NixInstantiate, flags)
+    }
+
+    /// Creates an invocation of `nix-store`.
+    pub fn nix_store(flags: NixFlags) -> Self {
+        Self::new(NixExe::NixStore, flags)
+    }
+
+    /// Creates an invocation of `nix-env`.
+    pub fn nix_env(flags: NixFlags) -> Self {
+        Self::new(NixExe::NixEnv, flags)
+    }
+
+    /// Creates an invocation of `nix-copy-closure`.
+    pub fn nix_copy_closure(flags: NixFlags) -> Self {
+        Self::new(NixExe::NixCopyClosure, flags)
+    }
+
+    /// Creates an invocation of `nix-eval-jobs` at the given path.
+    pub fn nix_eval_jobs(executable: PathBuf, flags: NixFlags) -> Self {
+        Self::new(NixExe::NixEvalJobs(executable), flags)
+    }
+
+    fn new(exe: NixExe, flags: NixFlags) -> Self {
+        Self {
+            exe,
+            flags,
+            extra_features: Vec::new(),
+            args: Vec::new(),
+        }
+    }
+
+    pub fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    pub fn args<I>(mut self, args: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<OsString>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    /// Enables additional experimental features.
+    pub fn extra_features(mut self, features: &[&'static str]) -> Self {
+        self.extra_features.extend_from_slice(features);
+        self
+    }
+
+    /// Builds a [`Command`] ready to be spawned locally.
+    pub fn build(self) -> Command {
+        let mut command = Command::new(self.exe.executable());
+        command.args(&self.args);
+        command.args(self.render_flags());
+        command
+    }
+
+    /// Returns the full argv, for execution on another host.
+    ///
+    /// All arguments must be valid UTF-8. The argv is unquoted:
+    /// transports that pass through a shell (like ssh) must escape
+    /// each element.
+    pub fn into_argv(self) -> Vec<String> {
+        let flags = self.render_flags();
+
+        let executable = self
+            .exe
+            .executable()
+            .into_owned()
+            .into_string()
+            .expect("Executable path must be valid UTF-8");
+
+        let mut argv = vec![executable];
+        argv.extend(
+            self.args
+                .into_iter()
+                .map(|arg| arg.into_string().expect("Arguments must be valid UTF-8")),
+        );
+        argv.extend(flags);
+        argv
+    }
+
+    /// Renders the [`NixFlags`] the executable accepts, followed by
+    /// the experimental features.
+    fn render_flags(&self) -> Vec<String> {
+        let caps = self.exe.caps();
+        let mut out = Vec::new();
+
+        let flags = &self.flags;
+
+        if caps.show_trace && flags.show_trace {
+            out.push("--show-trace".to_string());
+        }
+
+        if caps.pure_eval && flags.pure_eval {
+            out.push("--pure-eval".to_string());
+        }
+
+        if caps.impure && flags.impure {
+            out.push("--impure".to_string());
+        }
+
+        if caps.options {
+            for (name, value) in flags.options.iter() {
+                out.push("--option".to_string());
+                out.push(name.to_string());
+                out.push(value.to_string());
+            }
+        }
+
+        // --extra-experimental-features appends to the setting while
+        // --option experimental-features replaces it, and Nix applies
+        // flags left to right, so the features must come after the
+        // options to survive a user-supplied experimental-features
+        let mut features: Vec<&str> = caps.features.to_vec();
+        for feature in &self.extra_features {
+            if !features.contains(feature) {
+                features.push(feature);
+            }
+        }
+        if !features.is_empty() {
+            out.push("--extra-experimental-features".to_string());
+            out.push(features.join(" "));
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_flags() -> NixFlags {
+        let mut flags = NixFlags::default();
+        flags.set_show_trace(true);
+        flags.set_impure(true);
+        flags.add_option("cores".to_string(), "4".to_string());
+        flags.add_option(
+            "substituters".to_string(),
+            "https://a https://b".to_string(),
+        );
+        flags
+    }
+
+    #[test]
+    fn test_nix_receives_all_flags() {
+        let argv = NixCommand::nix(test_flags()).arg("eval").into_argv();
+
+        assert_eq!(
+            argv,
+            vec![
+                "nix",
+                "eval",
+                "--show-trace",
+                "--impure",
+                "--option",
+                "cores",
+                "4",
+                "--option",
+                "substituters",
+                "https://a https://b",
+                "--extra-experimental-features",
+                "nix-command flakes",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_features_survive_user_experimental_features() {
+        let mut flags = NixFlags::default();
+        flags.add_option(
+            "experimental-features".to_string(),
+            "ca-derivations".to_string(),
+        );
+
+        let argv = NixCommand::nix(flags).into_argv();
+
+        // the appending --extra-experimental-features must come after
+        // the replacing --option to keep nix-command and flakes enabled
+        assert_eq!(
+            argv,
+            vec![
+                "nix",
+                "--option",
+                "experimental-features",
+                "ca-derivations",
+                "--extra-experimental-features",
+                "nix-command flakes",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_nix_store_drops_impure() {
+        let argv = NixCommand::nix_store(test_flags())
+            .args(["--no-gc-warning", "--realise"])
+            .into_argv();
+
+        assert!(!argv.contains(&"--impure".to_string()));
+        assert!(argv.contains(&"--show-trace".to_string()));
+        assert!(argv.contains(&"cores".to_string()));
+    }
+
+    #[test]
+    fn test_nix_env_drops_impure() {
+        let argv = NixCommand::nix_env(test_flags())
+            .args(["--profile", "/nix/var/nix/profiles/system", "--set"])
+            .into_argv();
+
+        assert!(!argv.contains(&"--impure".to_string()));
+        assert!(argv.contains(&"--show-trace".to_string()));
+        assert!(argv.contains(&"cores".to_string()));
+    }
+
+    #[test]
+    fn test_nix_copy_closure_drops_impure() {
+        let argv = NixCommand::nix_copy_closure(test_flags())
+            .args(["--to", "user@host"])
+            .into_argv();
+
+        // nix-copy-closure would misparse --impure as a positional argument
+        assert!(!argv.contains(&"--impure".to_string()));
+        assert!(argv.contains(&"--show-trace".to_string()));
+        assert!(argv.contains(&"cores".to_string()));
+    }
+
+    #[test]
+    fn test_builders_option() {
+        let mut flags = NixFlags::default();
+        flags.set_builders(Some("@/path/to/machines".to_string()));
+
+        let argv = NixCommand::nix_store(flags).into_argv();
+
+        assert_eq!(
+            argv,
+            vec!["nix-store", "--option", "builders", "@/path/to/machines"]
+        );
+    }
+
+    #[test]
+    fn test_extra_features_dedup() {
+        let argv = NixCommand::nix(NixFlags::default())
+            .extra_features(&["flakes"])
+            .into_argv();
+
+        assert_eq!(
+            argv,
+            vec!["nix", "--extra-experimental-features", "nix-command flakes"]
+        );
+    }
+
+    #[test]
+    fn test_pure_eval() {
+        let mut flags = NixFlags::default();
+        flags.set_pure_eval(true);
+
+        // pure-eval is a setting, and setting flags are accepted by
+        // the legacy binaries as well
+        let argv = NixCommand::nix_store(flags).into_argv();
+        assert_eq!(argv, vec!["nix-store", "--pure-eval"]);
+    }
+}

--- a/src/nix/deployment/mod.rs
+++ b/src/nix/deployment/mod.rs
@@ -49,8 +49,8 @@ pub struct Deployment {
     /// Deployment options.
     options: Options,
 
-    /// Options passed to Nix invocations.
-    nix_options: NixFlags,
+    /// Flags passed to Nix invocations.
+    nix_flags: NixFlags,
 
     /// Handle to send messages to the ProgressOutput.
     progress: Option<ProgressSender>,
@@ -103,7 +103,7 @@ impl Deployment {
             hive,
             goal,
             options: Options::default(),
-            nix_options: NixFlags::default(),
+            nix_flags: NixFlags::default(),
             progress,
             targets,
             parallelism_limit: ParallelismLimit::default(),
@@ -129,8 +129,7 @@ impl Deployment {
             monitor.set_label_width(width);
         }
 
-        let nix_options = self.hive.nix_flags_with_builders().await?;
-        self.nix_options = nix_options;
+        self.nix_flags = self.hive.nix_flags_with_builders().await?;
 
         if self.goal == Goal::UploadKeys {
             // Just upload keys
@@ -505,7 +504,7 @@ impl Deployment {
         let profile: Profile = build_job
             .run(|job| async move {
                 // FIXME: Remote builder?
-                let mut builder = LocalHost::new(arc_self.nix_options.clone()).upcast();
+                let mut builder = LocalHost::new(arc_self.nix_flags.clone()).upcast();
                 builder.set_job(Some(job.clone()));
 
                 let profile = profile_drv.realize(&mut builder).await?;
@@ -525,7 +524,7 @@ impl Deployment {
                     job.state(JobState::Running)?;
                     let path = dir.join(".gcroots").join(format!("node-{}", &*target.name));
 
-                    profile_r.create_gc_root(&path).await?;
+                    profile_r.create_gc_root(&path, &arc_self.nix_flags).await?;
                 } else {
                     job.noop("No context directory to create GC roots in".to_string())?;
                 }

--- a/src/nix/evaluator/nix_eval_jobs.rs
+++ b/src/nix/evaluator/nix_eval_jobs.rs
@@ -14,12 +14,11 @@ use async_trait::async_trait;
 use futures::Stream;
 use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
 
 use super::{AttributeError, AttributeOutput, DrvSetEvaluator, EvalError, EvalResult};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::{JobHandle, null_job_handle};
-use crate::nix::{NixExpression, NixFlags, StorePath};
+use crate::nix::{NixCommand, NixExpression, NixFlags, StorePath};
 use crate::util::capture_stream;
 
 /// The pinned nix-eval-jobs binary.
@@ -76,25 +75,25 @@ impl DrvSetEvaluator for NixEvalJobs {
         expression: &dyn NixExpression,
         flags: NixFlags,
     ) -> ColmenaResult<Pin<Box<dyn Stream<Item = EvalResult>>>> {
-        let mut command = Command::new(&self.executable);
-        command.arg("--workers").arg(self.workers.to_string());
+        let mut command = NixCommand::nix_eval_jobs(self.executable.clone(), flags)
+            .arg("--workers")
+            .arg(self.workers.to_string());
 
         if let Some(installable) = expression.installable() {
-            command.args([
-                "--flake",
-                &installable,
-                "--select",
-                &expression.expression(),
-            ]);
+            command = command
+                .arg("--flake")
+                .arg(installable)
+                .arg("--select")
+                .arg(expression.expression());
         } else {
-            command.args(["--expr", &expression.expression()]);
+            command = command.arg("--expr").arg(expression.expression());
         }
-
-        command.args(flags.to_args());
 
         if expression.requires_flakes() {
-            command.args(["--extra-experimental-features", "flakes"]);
+            command = command.extra_features(&["flakes"]);
         }
+
+        let mut command = command.build();
 
         let mut child = command
             .stderr(Stdio::piped())

--- a/src/nix/flake.rs
+++ b/src/nix/flake.rs
@@ -7,7 +7,7 @@ use std::process::Stdio;
 use serde::Deserialize;
 use tokio::process::Command;
 
-use super::{ColmenaError, ColmenaResult, NixCheck};
+use super::{ColmenaError, ColmenaResult};
 
 /// A Nix Flake.
 #[derive(Debug, Clone)]
@@ -36,8 +36,6 @@ impl Flake {
     /// This will try to retrieve the resolved URL of the local flake
     /// in the specified directory.
     pub async fn from_dir<P: AsRef<Path>>(dir: P) -> ColmenaResult<Self> {
-        NixCheck::require_flake_support().await?;
-
         let flake = dir
             .as_ref()
             .as_os_str()
@@ -54,8 +52,6 @@ impl Flake {
 
     /// Creates a flake from a Flake URI.
     pub async fn from_uri(uri: impl AsRef<str>) -> ColmenaResult<Self> {
-        NixCheck::require_flake_support().await?;
-
         let metadata = FlakeMetadata::resolve(uri.as_ref()).await?;
 
         Ok(Self {

--- a/src/nix/flake.rs
+++ b/src/nix/flake.rs
@@ -5,9 +5,8 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use serde::Deserialize;
-use tokio::process::Command;
 
-use super::{ColmenaError, ColmenaResult};
+use super::{ColmenaError, ColmenaResult, NixCommand, NixFlags};
 
 /// A Nix Flake.
 #[derive(Debug, Clone)]
@@ -35,14 +34,14 @@ impl Flake {
     ///
     /// This will try to retrieve the resolved URL of the local flake
     /// in the specified directory.
-    pub async fn from_dir<P: AsRef<Path>>(dir: P) -> ColmenaResult<Self> {
+    pub async fn from_dir<P: AsRef<Path>>(dir: P, flags: &NixFlags) -> ColmenaResult<Self> {
         let flake = dir
             .as_ref()
             .as_os_str()
             .to_str()
             .expect("Flake directory path contains non-UTF-8 characters");
 
-        let metadata = FlakeMetadata::resolve(flake).await?;
+        let metadata = FlakeMetadata::resolve(flake, flags).await?;
 
         Ok(Self {
             metadata,
@@ -51,8 +50,8 @@ impl Flake {
     }
 
     /// Creates a flake from a Flake URI.
-    pub async fn from_uri(uri: impl AsRef<str>) -> ColmenaResult<Self> {
-        let metadata = FlakeMetadata::resolve(uri.as_ref()).await?;
+    pub async fn from_uri(uri: impl AsRef<str>, flags: &NixFlags) -> ColmenaResult<Self> {
+        let metadata = FlakeMetadata::resolve(uri.as_ref(), flags).await?;
 
         Ok(Self {
             metadata,
@@ -81,12 +80,11 @@ impl Flake {
 
 impl FlakeMetadata {
     /// Resolves a flake.
-    async fn resolve(flake: &str) -> ColmenaResult<Self> {
-        let child = Command::new("nix")
-            .args(["flake", "metadata", "--json"])
-            .args(["--extra-experimental-features", "nix-command flakes"])
-            .args(["--no-write-lock-file"])
+    async fn resolve(flake: &str, flags: &NixFlags) -> ColmenaResult<Self> {
+        let child = NixCommand::nix(flags.clone())
+            .args(["flake", "metadata", "--json", "--no-write-lock-file"])
             .arg(flake)
+            .build()
             .stdout(Stdio::piped())
             .spawn()?;
 
@@ -104,11 +102,11 @@ impl FlakeMetadata {
 }
 
 /// Quietly locks the dependencies of a flake.
-pub async fn lock_flake_quiet(uri: &str) -> ColmenaResult<()> {
-    let status = Command::new("nix")
+pub async fn lock_flake_quiet(uri: &str, flags: &NixFlags) -> ColmenaResult<()> {
+    let status = NixCommand::nix(flags.clone())
         .args(["flake", "lock"])
-        .args(["--extra-experimental-features", "nix-command flakes"])
         .arg(uri)
+        .build()
         .stderr(Stdio::null())
         .status()
         .await?;

--- a/src/nix/hive/assets.rs
+++ b/src/nix/hive/assets.rs
@@ -13,6 +13,7 @@ use tempfile::{Builder as TempFileBuilder, TempDir};
 
 use super::{Flake, HivePath};
 use crate::error::ColmenaResult;
+use crate::nix::NixFlags;
 use crate::nix::flake::lock_flake_quiet;
 
 const FLAKE_NIX: &str = include_str!("flake.nix");
@@ -34,7 +35,7 @@ pub(super) struct Assets {
 }
 
 impl Assets {
-    pub async fn new(hive_path: HivePath) -> ColmenaResult<Self> {
+    pub async fn new(hive_path: HivePath, flags: &NixFlags) -> ColmenaResult<Self> {
         let temp_dir = TempFileBuilder::new().prefix("colmena-assets-").tempdir()?;
 
         create_file(&temp_dir, "eval.nix", false, EVAL_NIX)?;
@@ -55,8 +56,8 @@ impl Assets {
                 "path:{}",
                 temp_dir.path().canonicalize().unwrap().to_str().unwrap()
             );
-            let _ = lock_flake_quiet(&uri).await;
-            let assets_flake = Flake::from_uri(uri).await?;
+            let _ = lock_flake_quiet(&uri, flags).await;
+            let assets_flake = Flake::from_uri(uri, flags).await?;
             assets_flake_uri = Some(assets_flake.locked_uri().to_owned());
         }
 

--- a/src/nix/hive/mod.rs
+++ b/src/nix/hive/mod.rs
@@ -6,7 +6,6 @@ mod tests;
 use std::collections::HashMap;
 use std::convert::AsRef;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use const_format::formatcp;
 use tokio::process::Command;
@@ -15,10 +14,10 @@ use validator::Validate;
 
 use super::deployment::TargetNode;
 use super::{
-    Flake, MetaConfig, NixExpression, NixFlags, NodeConfig, NodeFilter, NodeName,
+    Flake, MetaConfig, NixCommand, NixExpression, NixFlags, NodeConfig, NodeFilter, NodeName,
     ProfileDerivation, SerializedNixExpression, StorePath,
 };
-use crate::error::{ColmenaError, ColmenaResult};
+use crate::error::ColmenaResult;
 use crate::job::JobHandle;
 use crate::util::{CommandExecution, CommandExt};
 use assets::Assets;
@@ -49,33 +48,23 @@ pub enum HivePath {
     Legacy(PathBuf),
 }
 
-impl FromStr for HivePath {
-    type Err = ColmenaError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+impl HivePath {
+    /// Resolves a path or a flake URI into a HivePath.
+    pub async fn resolve(s: &str, flags: &NixFlags) -> ColmenaResult<Self> {
         // TODO: check for escaped colon maybe?
 
-        let s = s.to_owned();
-        let path = std::path::PathBuf::from(&s);
+        let path = std::path::PathBuf::from(s);
 
-        let fut = async move {
-            if !path.exists() && s.contains(':') {
-                // Treat as flake URI
-                let flake = Flake::from_uri(s).await?;
+        if !path.exists() && s.contains(':') {
+            // Treat as flake URI
+            let flake = Flake::from_uri(s, flags).await?;
 
-                tracing::info!("Using flake: {}", flake.uri());
+            tracing::info!("Using flake: {}", flake.uri());
 
-                Ok(Self::Flake(flake))
-            } else {
-                HivePath::from_path(path).await
-            }
-        };
-
-        let handle = tokio::runtime::Handle::try_current()
-            .expect("We should always be executed after we have a runtime");
-        std::thread::spawn(move || handle.block_on(fut))
-            .join()
-            .expect("Failed to join future")
+            Ok(Self::Flake(flake))
+        } else {
+            Self::from_path(path, flags).await
+        }
     }
 }
 
@@ -116,14 +105,12 @@ pub struct Hive {
     /// Static files required to evaluate a Hive configuration.
     assets: Assets,
 
-    /// Whether to pass --show-trace in Nix commands.
-    show_trace: bool,
-
-    /// Whether to pass --impure in Nix commands.
-    impure: bool,
-
-    /// Options to pass as --option name value.
-    nix_options: HashMap<String, String>,
+    /// Flags to pass to Nix commands.
+    ///
+    /// This is the single source of truth for the flags: every Nix
+    /// invocation made on behalf of this Hive derives its flags from
+    /// here via `nix_flags()` or `nix_flags_with_builders()`.
+    flags: NixFlags,
 
     meta_config: OnceCell<MetaConfig>,
 }
@@ -140,14 +127,14 @@ struct EvalSelectedExpression<'hive> {
 }
 
 impl HivePath {
-    pub async fn from_path<P: AsRef<Path>>(path: P) -> ColmenaResult<Self> {
+    pub async fn from_path<P: AsRef<Path>>(path: P, flags: &NixFlags) -> ColmenaResult<Self> {
         let path = path.as_ref();
 
         if let Some(osstr) = path.file_name()
             && osstr == "flake.nix"
         {
             let parent = path.parent().unwrap();
-            let flake = Flake::from_dir(parent).await?;
+            let flake = Flake::from_dir(parent, flags).await?;
             return Ok(Self::Flake(flake));
         }
 
@@ -167,10 +154,10 @@ impl HivePath {
 }
 
 impl Hive {
-    pub async fn new(path: HivePath) -> ColmenaResult<Self> {
+    pub async fn new(path: HivePath, flags: NixFlags) -> ColmenaResult<Self> {
         let context_dir = path.context_dir();
         // TODO: Skip asset extraction for direct flake eval
-        let assets = Assets::new(path.clone()).await?;
+        let assets = Assets::new(path.clone(), &flags).await?;
 
         let evaluation_method = if path.is_flake() {
             EvaluationMethod::DirectFlakeEval
@@ -183,9 +170,7 @@ impl Hive {
             evaluation_method,
             context_dir,
             assets,
-            show_trace: false,
-            impure: false,
-            nix_options: HashMap::new(),
+            flags,
             meta_config: OnceCell::new(),
         })
     }
@@ -213,25 +198,16 @@ impl Hive {
         self.evaluation_method = method;
     }
 
+    #[cfg(test)]
     pub fn set_show_trace(&mut self, value: bool) {
-        self.show_trace = value;
+        self.flags.set_show_trace(value);
     }
 
-    pub fn set_impure(&mut self, impure: bool) {
-        self.impure = impure;
-    }
-
-    pub fn add_nix_option(&mut self, name: String, value: String) {
-        self.nix_options.insert(name, value);
-    }
-
-    /// Returns Nix options to set for this Hive.
+    /// Returns Nix flags for evaluating this Hive, with pure
+    /// evaluation enabled when the hive is a flake.
     pub fn nix_flags(&self) -> NixFlags {
-        let mut flags = NixFlags::default();
-        flags.set_show_trace(self.show_trace);
+        let mut flags = self.flags.clone();
         flags.set_pure_eval(self.path.is_flake());
-        flags.set_impure(self.impure);
-        flags.set_options(self.nix_options.clone());
         flags
     }
 
@@ -515,50 +491,33 @@ impl<'hive> NixInstantiate<'hive> {
         Self { hive, expression }
     }
 
-    fn instantiate(&self) -> Command {
+    fn instantiate(&self, flags: NixFlags) -> NixCommand {
         // TODO: Better error handling
         if self.hive.evaluation_method == EvaluationMethod::DirectFlakeEval {
             panic!("Instantiation is not supported with DirectFlakeEval");
         }
 
-        let mut command = Command::new("nix-instantiate");
-
-        if self.hive.is_flake() {
-            command.args(["--extra-experimental-features", "flakes"]);
-        }
-
         let mut full_expression = self.hive.get_base_expression();
         full_expression += &self.expression;
 
-        command
-            .arg("--no-gc-warning")
-            .arg("-E")
-            .arg(&full_expression);
+        let mut command = NixCommand::nix_instantiate(flags);
 
-        command
+        if self.hive.is_flake() {
+            command = command.extra_features(&["flakes"]);
+        }
+
+        command.args(["--no-gc-warning", "-E"]).arg(full_expression)
     }
 
-    fn eval(self) -> Command {
-        let flags = self.hive.nix_flags();
-
+    fn eval_command(&self, flags: NixFlags) -> NixCommand {
         match self.hive.evaluation_method {
-            EvaluationMethod::NixInstantiate => {
-                let mut command = self.instantiate();
-
-                command
-                    .arg("--eval")
-                    .arg("--json")
-                    .arg("--strict")
-                    // Ensures the derivations are instantiated
-                    // Required for system profile evaluation and IFD
-                    .arg("--read-write-mode")
-                    .args(flags.to_args());
-
-                command
-            }
+            EvaluationMethod::NixInstantiate => self
+                .instantiate(flags)
+                .args(["--eval", "--json", "--strict"])
+                // Ensures the derivations are instantiated
+                // Required for system profile evaluation and IFD
+                .arg("--read-write-mode"),
             EvaluationMethod::DirectFlakeEval => {
-                let mut command = Command::new("nix");
-
                 let hive_installable = self
                     .hive
                     .flake_installable()
@@ -567,36 +526,28 @@ impl<'hive> NixInstantiate<'hive> {
                 let mut full_expression = self.hive.get_base_expression();
                 full_expression += &self.expression;
 
-                command
+                NixCommand::nix(flags)
                     .arg("eval") // nix eval
-                    .args(["--extra-experimental-features", "flakes nix-command"])
                     .arg(hive_installable)
-                    .arg("--json")
-                    .arg("--apply")
-                    .arg(&full_expression)
-                    .args(flags.to_args());
-
-                command
+                    .args(["--json", "--apply"])
+                    .arg(full_expression)
             }
         }
     }
 
+    fn eval(self) -> Command {
+        let flags = self.hive.nix_flags();
+        self.eval_command(flags).build()
+    }
+
     async fn instantiate_with_builders(self) -> ColmenaResult<Command> {
         let flags = self.hive.nix_flags_with_builders().await?;
-        let mut command = self.instantiate();
-
-        command.args(flags.to_args());
-
-        Ok(command)
+        Ok(self.instantiate(flags).build())
     }
 
     async fn eval_with_builders(self) -> ColmenaResult<Command> {
         let flags = self.hive.nix_flags_with_builders().await?;
-        let mut command = self.eval();
-
-        command.args(flags.to_args());
-
-        Ok(command)
+        Ok(self.eval_command(flags).build())
     }
 }
 

--- a/src/nix/hive/mod.rs
+++ b/src/nix/hive/mod.rs
@@ -239,7 +239,10 @@ impl Hive {
     pub async fn nix_flags_with_builders(&self) -> ColmenaResult<NixFlags> {
         let mut flags = self.nix_flags();
 
-        if let Some(machines_file) = &self.get_meta_config().await?.machines_file {
+        // an explicit --nix-option builders overrides meta.machinesFile
+        if let Some(machines_file) = &self.get_meta_config().await?.machines_file
+            && !flags.has_option("builders")
+        {
             flags.set_builders(Some(format!("@{}", machines_file)));
         }
 

--- a/src/nix/hive/mod.rs
+++ b/src/nix/hive/mod.rs
@@ -211,6 +211,17 @@ impl Hive {
         flags
     }
 
+    /// Returns Nix flags for invocations on a deployment target.
+    ///
+    /// Unlike [`Hive::nix_flags`], evaluation-context values are left
+    /// out: --pure-eval only affects evaluation, which never happens
+    /// on the target (and old Nix there may not know the flag), and
+    /// the machines file refers to a path on the local machine that
+    /// most likely does not exist on the target.
+    pub fn nix_flags_for_remote(&self) -> NixFlags {
+        self.flags.clone()
+    }
+
     /// Returns Nix flags to set for this Hive, with configured remote builders.
     pub async fn nix_flags_with_builders(&self) -> ColmenaResult<NixFlags> {
         let mut flags = self.nix_flags();
@@ -269,10 +280,13 @@ impl Hive {
 
         let mut targets = HashMap::new();
         let mut n_ssh = 0;
+
+        let nix_flags = self.nix_flags_for_remote();
+
         for node in selected_nodes.into_iter() {
             let config = node_configs.remove(&node).unwrap();
 
-            let host = config.to_ssh_host().map(|mut host| {
+            let host = config.to_ssh_host(nix_flags.clone()).map(|mut host| {
                 n_ssh += 1;
 
                 if let Some(ssh_config) = &ssh_config {

--- a/src/nix/hive/tests/mod.rs
+++ b/src/nix/hive/tests/mod.rs
@@ -707,6 +707,34 @@ fn test_hive_get_meta() {
 }
 
 #[test]
+fn test_remote_flags_exclude_machines_file() {
+    let mut flags = NixFlags::default();
+    flags.add_option("cores".to_string(), "4".to_string());
+
+    let hive = TempHive::with_flags(
+        r#"
+      {
+        meta.machinesFile = "/etc/nix/machines";
+      }
+    "#,
+        flags,
+    );
+
+    let with_builders = block_on(hive.nix_flags_with_builders()).unwrap();
+    let argv = NixCommand::nix_store(with_builders).into_argv();
+    assert!(
+        argv.windows(3)
+            .any(|w| w == ["--option", "builders", "@/etc/nix/machines"])
+    );
+    assert!(argv.windows(3).any(|w| w == ["--option", "cores", "4"]));
+
+    // the machines file refers to a local path and --pure-eval only
+    // affects evaluation, so neither may reach a deployment target
+    let remote = NixCommand::nix_store(hive.nix_flags_for_remote()).into_argv();
+    assert_eq!(remote, vec!["nix-store", "--option", "cores", "4"]);
+}
+
+#[test]
 fn test_user_builders_override_machines_file() {
     let mut flags = NixFlags::default();
     flags.add_option("builders".to_string(), "@/custom/machines".to_string());

--- a/src/nix/hive/tests/mod.rs
+++ b/src/nix/hive/tests/mod.rs
@@ -37,11 +37,15 @@ struct TempHive {
 
 impl TempHive {
     pub fn new(text: &str) -> Self {
+        Self::with_flags(text, NixFlags::default())
+    }
+
+    pub fn with_flags(text: &str, flags: NixFlags) -> Self {
         let mut temp_file = NamedTempFile::new().unwrap();
         temp_file.write_all(text.as_bytes()).unwrap();
 
-        let hive_path = block_on(HivePath::from_path(temp_file.path())).unwrap();
-        let hive = block_on(Hive::new(hive_path)).unwrap();
+        let hive_path = block_on(HivePath::from_path(temp_file.path(), &flags)).unwrap();
+        let hive = block_on(Hive::new(hive_path, flags)).unwrap();
 
         Self {
             hive,
@@ -187,10 +191,10 @@ fn test_parse_makehive_flake() {
     fs::write(flake_nix, patched_flake).unwrap();
 
     // run the test
-    let flake = block_on(Flake::from_dir(flake_dir.as_ref())).unwrap();
+    let flake = block_on(Flake::from_dir(flake_dir.as_ref(), &NixFlags::default())).unwrap();
 
     let hive_path = HivePath::Flake(flake);
-    let mut hive = block_on(Hive::new(hive_path)).unwrap();
+    let mut hive = block_on(Hive::new(hive_path, NixFlags::default())).unwrap();
 
     hive.set_show_trace(true);
 
@@ -700,4 +704,27 @@ fn test_hive_get_meta() {
     eprintln!("{:?}", eval);
 
     assert!(!eval.allow_apply_all);
+}
+
+#[test]
+fn test_user_builders_override_machines_file() {
+    let mut flags = NixFlags::default();
+    flags.add_option("builders".to_string(), "@/custom/machines".to_string());
+
+    let hive = TempHive::with_flags(
+        r#"
+      {
+        meta.machinesFile = "/etc/nix/machines";
+      }
+    "#,
+        flags,
+    );
+
+    let with_builders = block_on(hive.nix_flags_with_builders()).unwrap();
+    let argv = NixCommand::nix_store(with_builders).into_argv();
+    assert!(
+        argv.windows(3)
+            .any(|w| w == ["--option", "builders", "@/custom/machines"])
+    );
+    assert!(!argv.contains(&"@/etc/nix/machines".to_string()));
 }

--- a/src/nix/host/local.rs
+++ b/src/nix/host/local.rs
@@ -18,15 +18,15 @@ use crate::util::{CommandExecution, CommandExt};
 #[derive(Debug)]
 pub struct Local {
     job: Option<JobHandle>,
-    nix_options: NixFlags,
+    nix_flags: NixFlags,
     privilege_escalation_command: Option<Vec<String>>,
 }
 
 impl Local {
-    pub fn new(nix_options: NixFlags) -> Self {
+    pub fn new(nix_flags: NixFlags) -> Self {
         Self {
             job: None,
-            nix_options,
+            nix_flags,
             privilege_escalation_command: None,
         }
     }
@@ -44,13 +44,7 @@ impl Host for Local {
     }
 
     async fn realize_remote(&mut self, derivation: &StorePath) -> ColmenaResult<Vec<StorePath>> {
-        let mut command = Command::new("nix-store");
-
-        command.args(self.nix_options.to_nix_store_args());
-        command
-            .arg("--no-gc-warning")
-            .arg("--realise")
-            .arg(derivation.as_path());
+        let command = derivation.realise_command(&self.nix_flags).build();
 
         let mut execution = CommandExecution::new(command);
 
@@ -84,10 +78,8 @@ impl Host for Local {
         }
 
         if goal.should_switch_profile() {
-            let path = profile.as_path().to_str().unwrap();
-            self.make_privileged_command(&["nix-env", "--profile", SYSTEM_PROFILE, "--set", path])
-                .passthrough()
-                .await?;
+            let argv = profile.switch_profile_command(&self.nix_flags).into_argv();
+            self.make_privileged_command(&argv).passthrough().await?;
         }
 
         let command = {

--- a/src/nix/host/ssh.rs
+++ b/src/nix/host/ssh.rs
@@ -6,13 +6,16 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use shell_escape::unix::escape;
 use tokio::process::Command;
 use tokio::time::sleep;
 
 use super::{CopyDirection, CopyOptions, Host, RebootOptions, key_uploader};
 use crate::error::{ColmenaError, ColmenaResult};
 use crate::job::JobHandle;
-use crate::nix::{CURRENT_PROFILE, Goal, Key, Profile, SYSTEM_PROFILE, StorePath};
+use crate::nix::{
+    CURRENT_PROFILE, Goal, Key, NixCommand, NixFlags, Profile, SYSTEM_PROFILE, StorePath,
+};
 use crate::util::{CommandExecution, CommandExt};
 
 /// A remote machine connected over SSH.
@@ -39,6 +42,9 @@ pub struct Ssh {
     /// Whether to use the experimental `nix copy` command.
     use_nix3_copy: bool,
 
+    /// Flags to pass to Nix invocations, local and remote.
+    nix_flags: NixFlags,
+
     job: Option<JobHandle>,
 }
 
@@ -59,12 +65,8 @@ impl Host for Ssh {
     }
 
     async fn realize_remote(&mut self, derivation: &StorePath) -> ColmenaResult<Vec<StorePath>> {
-        let command = self.ssh(&[
-            "nix-store",
-            "--no-gc-warning",
-            "--realise",
-            derivation.as_path().to_str().unwrap(),
-        ]);
+        let argv = derivation.realise_command(&self.nix_flags).into_argv();
+        let command = self.ssh_argv(argv);
 
         let mut execution = CommandExecution::new(command);
         execution.set_job(self.job.clone());
@@ -96,14 +98,13 @@ impl Host for Ssh {
         }
 
         if goal.should_switch_profile() {
-            let path = profile.as_path().to_str().unwrap();
-            let set_profile = self.ssh(&["nix-env", "--profile", SYSTEM_PROFILE, "--set", path]);
+            let argv = profile.switch_profile_command(&self.nix_flags).into_argv();
+            let set_profile = self.ssh_argv(argv);
             self.run_command(set_profile).await?;
         }
 
         let activation_command = profile.activation_command(goal).unwrap();
-        let v: Vec<&str> = activation_command.iter().map(|s| &**s).collect();
-        let command = self.ssh(&v);
+        let command = self.ssh(&activation_command);
         self.run_command(command).await
     }
 
@@ -129,7 +130,10 @@ impl Host for Ssh {
             SYSTEM_PROFILE, CURRENT_PROFILE
         );
 
-        let paths = self.ssh(&["sh", "-c", &command]).capture_output().await?;
+        let paths = self
+            .ssh(&["sh", "-c", command.as_str()])
+            .capture_output()
+            .await?;
 
         let path = paths
             .lines()
@@ -185,7 +189,7 @@ impl Host for Ssh {
 }
 
 impl Ssh {
-    pub fn new(user: Option<String>, host: String) -> Self {
+    pub fn new(user: Option<String>, host: String, nix_flags: NixFlags) -> Self {
         Self {
             user,
             host,
@@ -194,6 +198,7 @@ impl Ssh {
             privilege_escalation_command: Vec::new(),
             extra_ssh_options: Vec::new(),
             use_nix3_copy: false,
+            nix_flags,
             job: None,
         }
     }
@@ -222,8 +227,23 @@ impl Ssh {
         Box::new(self)
     }
 
+    /// Returns a Tokio Command to run a generated command on the host.
+    ///
+    /// ssh(1) concatenates its arguments with spaces and lets the remote
+    /// shell re-split them, so each argument is escaped first. This
+    /// matters for Nix flag values that may contain spaces (e.g.,
+    /// `--option substituters "https://a https://b"`).
+    fn ssh_argv(&self, argv: Vec<String>) -> Command {
+        let escaped: Vec<String> = argv
+            .into_iter()
+            .map(|arg| escape(arg.into()).into_owned())
+            .collect();
+
+        self.ssh(&escaped)
+    }
+
     /// Returns a Tokio Command to run an arbitrary command on the host.
-    pub fn ssh(&self, command: &[&str]) -> Command {
+    pub fn ssh<S: AsRef<OsStr>>(&self, command: &[S]) -> Command {
         let options = self.ssh_options();
         let options_str = options.join(" ");
         let privilege_escalation_command = if self.user.as_deref() != Some("root") {
@@ -269,17 +289,11 @@ impl Ssh {
 
         let mut command = if self.use_nix3_copy {
             // experimental `nix copy` command with ssh-ng://
-            let mut command = Command::new("nix");
-
-            command.args([
-                "--extra-experimental-features",
-                "nix-command",
-                "copy",
-                "--no-check-sigs",
-            ]);
+            let mut command =
+                NixCommand::nix(self.nix_flags.clone()).args(["copy", "--no-check-sigs"]);
 
             if options.use_substitutes {
-                command.args([
+                command = command.args([
                     "--substitute-on-destination",
                     // needed due to UX bug in ssh-ng://
                     "--builders-use-substitutes",
@@ -287,54 +301,41 @@ impl Ssh {
             }
 
             if let Some("drv") = path.extension().and_then(OsStr::to_str) {
-                command.arg("--derivation");
+                command = command.arg("--derivation");
             }
 
-            match direction {
-                CopyDirection::ToRemote => {
-                    command.arg("--to");
-                }
-                CopyDirection::FromRemote => {
-                    command.arg("--from");
-                }
-            }
+            command = match direction {
+                CopyDirection::ToRemote => command.arg("--to"),
+                CopyDirection::FromRemote => command.arg("--from"),
+            };
 
             let mut store_uri = format!("ssh-ng://{}", self.ssh_target());
             if options.gzip {
                 store_uri += "?compress=true";
             }
-            command.arg(store_uri);
 
-            command.arg(path.as_path());
-
-            command
+            command.arg(store_uri).arg(path.as_path()).build()
         } else {
             // nix-copy-closure (ssh://)
-            let mut command = Command::new("nix-copy-closure");
+            let mut command = NixCommand::nix_copy_closure(self.nix_flags.clone());
 
-            match direction {
-                CopyDirection::ToRemote => {
-                    command.arg("--to");
-                }
-                CopyDirection::FromRemote => {
-                    command.arg("--from");
-                }
-            }
+            command = match direction {
+                CopyDirection::ToRemote => command.arg("--to"),
+                CopyDirection::FromRemote => command.arg("--from"),
+            };
 
             // FIXME: Host-agnostic abstraction
             if options.include_outputs {
-                command.arg("--include-outputs");
+                command = command.arg("--include-outputs");
             }
             if options.use_substitutes {
-                command.arg("--use-substitutes");
+                command = command.arg("--use-substitutes");
             }
             if options.gzip {
-                command.arg("--gzip");
+                command = command.arg("--gzip");
             }
 
-            command.arg(self.ssh_target()).arg(path.as_path());
-
-            command
+            command.arg(self.ssh_target()).arg(path.as_path()).build()
         };
 
         command.env("NIX_SSHOPTS", ssh_options_str);
@@ -394,7 +395,7 @@ impl Ssh {
         let path = key.path();
         let key_script = key_uploader::generate_script(key, path, require_ownership);
 
-        let mut command = self.ssh(&["sh", "-c", &key_script]);
+        let mut command = self.ssh(&["sh", "-c", key_script.as_ref()]);
 
         command.stdin(Stdio::piped());
         command.stderr(Stdio::piped());
@@ -426,6 +427,75 @@ impl Ssh {
                     Err(e)
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ssh_argv_escapes_for_remote_shell() {
+        let mut flags = NixFlags::default();
+        flags.add_option(
+            "substituters".to_string(),
+            "https://a https://b".to_string(),
+        );
+
+        let host = Ssh::new(Some("root".to_string()), "example.com".to_string(), flags);
+
+        let argv = NixCommand::nix_store(host.nix_flags.clone())
+            .args(["--no-gc-warning", "--realise"])
+            .arg("/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x")
+            .into_argv();
+        let command = host.ssh_argv(argv);
+
+        let args: Vec<String> = command
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        // The space-containing option value must be quoted for the
+        // remote shell...
+        assert!(args.contains(&"'https://a https://b'".to_string()));
+        // ...while plain arguments are passed through unchanged.
+        assert!(args.contains(&"--realise".to_string()));
+        assert!(args.contains(&"nix-store".to_string()));
+    }
+
+    #[test]
+    fn test_copy_closure_threads_nix_flags() {
+        let mut flags = NixFlags::default();
+        flags.add_option("cores".to_string(), "4".to_string());
+
+        let mut host = Ssh::new(Some("root".to_string()), "example.com".to_string(), flags);
+
+        let store_path: StorePath = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x"
+            .to_string()
+            .try_into()
+            .unwrap();
+
+        // Exercise the production path for both copy backends.
+        for use_nix3_copy in [false, true] {
+            host.set_use_nix3_copy(use_nix3_copy);
+
+            let command =
+                host.nix_copy_closure(&store_path, CopyDirection::ToRemote, CopyOptions::default());
+
+            let args: Vec<String> = command
+                .as_std()
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect();
+
+            assert!(
+                args.windows(3).any(|w| w == ["--option", "cores", "4"]),
+                "nix_flags not threaded (use_nix3_copy: {}): {:?}",
+                use_nix3_copy,
+                args
+            );
         }
     }
 }

--- a/src/nix/info.rs
+++ b/src/nix/info.rs
@@ -2,7 +2,8 @@ use std::fmt;
 use std::process::Stdio;
 
 use regex::Regex;
-use tokio::process::Command;
+
+use super::{NixCommand, NixFlags};
 
 pub struct NixVersion {
     major: usize,
@@ -53,35 +54,36 @@ impl NixCheck {
         flakes_enabled: false,
     };
 
-    pub async fn detect() -> Self {
-        let version_cmd = Command::new("nix-instantiate")
-            .arg("--version")
-            .output()
-            .await;
+    pub async fn detect(flags: &NixFlags) -> Self {
+        // The version probe detects the Nix installation itself, so it
+        // deliberately runs without the user-supplied flags: a bogus
+        // --option must not make the version appear undetectable. The
+        // flakes probe reflects the effective configuration, so the
+        // user-supplied flags apply (e.g., experimental-features
+        // enabled via --nix-option).
+        let (version_cmd, flake_cmd) = tokio::join!(
+            NixCommand::nix_instantiate(NixFlags::default())
+                .arg("--version")
+                .build()
+                .output(),
+            NixCommand::nix_instantiate(flags.clone())
+                .args(["--eval", "-E", "builtins.getFlake"])
+                .build()
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status(),
+        );
 
-        if version_cmd.is_err() {
+        let (Ok(version_output), Ok(flake_status)) = (version_cmd, flake_cmd) else {
             return Self::NO_NIX;
-        }
+        };
 
         let version =
-            NixVersion::parse(String::from_utf8_lossy(&version_cmd.unwrap().stdout).to_string());
-
-        let flake_cmd = Command::new("nix-instantiate")
-            .args(["--eval", "-E", "builtins.getFlake"])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
-
-        if flake_cmd.is_err() {
-            return Self::NO_NIX;
-        }
-
-        let flakes_enabled = flake_cmd.unwrap().success();
+            NixVersion::parse(String::from_utf8_lossy(&version_output.stdout).to_string());
 
         Self {
             version: Some(version),
-            flakes_enabled,
+            flakes_enabled: flake_status.success(),
         }
     }
 

--- a/src/nix/info.rs
+++ b/src/nix/info.rs
@@ -4,8 +4,6 @@ use std::process::Stdio;
 use regex::Regex;
 use tokio::process::Command;
 
-use super::{ColmenaError, ColmenaResult};
-
 pub struct NixVersion {
     major: usize,
     minor: usize,
@@ -32,14 +30,6 @@ impl NixVersion {
             }
         }
     }
-
-    fn has_flakes(&self) -> bool {
-        self.major > 2 || (self.major == 2 && self.minor >= 4)
-    }
-
-    pub fn at_least(&self, major: usize, minor: usize) -> bool {
-        self.major >= major && self.minor >= minor
-    }
 }
 
 impl fmt::Display for NixVersion {
@@ -54,14 +44,12 @@ impl fmt::Display for NixVersion {
 
 pub struct NixCheck {
     version: Option<NixVersion>,
-    flakes_supported: bool,
     flakes_enabled: bool,
 }
 
 impl NixCheck {
     const NO_NIX: Self = Self {
         version: None,
-        flakes_supported: false,
         flakes_enabled: false,
     };
 
@@ -77,7 +65,6 @@ impl NixCheck {
 
         let version =
             NixVersion::parse(String::from_utf8_lossy(&version_cmd.unwrap().stdout).to_string());
-        let flakes_supported = version.has_flakes();
 
         let flake_cmd = Command::new("nix-instantiate")
             .args(["--eval", "-E", "builtins.getFlake"])
@@ -94,19 +81,7 @@ impl NixCheck {
 
         Self {
             version: Some(version),
-            flakes_supported,
             flakes_enabled,
-        }
-    }
-
-    pub async fn require_flake_support() -> ColmenaResult<()> {
-        let check = Self::detect().await;
-
-        if !check.flakes_supported() {
-            check.print_flakes_info(true);
-            Err(ColmenaError::NoFlakesSupport)
-        } else {
-            Ok(())
         }
     }
 
@@ -118,7 +93,7 @@ impl NixCheck {
         }
     }
 
-    pub fn print_flakes_info(&self, required: bool) {
+    pub fn print_flakes_info(&self) {
         if self.version.is_none() {
             tracing::error!("Nix doesn't appear to be installed.");
             return;
@@ -126,36 +101,12 @@ impl NixCheck {
 
         if self.flakes_enabled {
             tracing::info!("The Nix version you are using supports Flakes and it's enabled.");
-        } else if self.flakes_supported {
+        } else {
             tracing::warn!("The Nix version you are using supports Flakes but it's disabled.");
             tracing::warn!(
                 "Colmena will automatically enable Flakes for its operations, but you should enable it in your Nix configuration:"
             );
             tracing::warn!("    experimental-features = nix-command flakes");
-        } else {
-            let emit_log = |s: &str| {
-                if required {
-                    tracing::error!(s);
-                } else {
-                    tracing::warn!(s);
-                }
-            };
-
-            emit_log("The Nix version you are using does not support Flakes.");
-            emit_log(
-                "If you are using a Nixpkgs version before 21.11, please install nixUnstable for a version that includes Flakes support.",
-            );
-            if required {
-                emit_log("Cannot continue since Flakes support is required for this operation.");
-            }
         }
-    }
-
-    pub fn flakes_supported(&self) -> bool {
-        self.flakes_supported
-    }
-
-    pub fn version(&self) -> Option<&NixVersion> {
-        self.version.as_ref()
     }
 }

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -9,8 +9,6 @@ use validator::{Validate, ValidationError as ValidationErrorType};
 
 use crate::error::{ColmenaError, ColmenaResult};
 
-// TODO: Remove the allow once call sites are ported (following commits)
-#[allow(dead_code)]
 pub mod command;
 pub use command::NixCommand;
 
@@ -179,9 +177,9 @@ impl NodeConfig {
         self.build_on_target = enable;
     }
 
-    pub fn to_ssh_host(&self) -> Option<Ssh> {
+    pub fn to_ssh_host(&self, nix_flags: NixFlags) -> Option<Ssh> {
         self.target_host.as_ref().map(|target_host| {
-            let mut host = Ssh::new(self.target_user.clone(), target_host.clone());
+            let mut host = Ssh::new(self.target_user.clone(), target_host.clone(), nix_flags);
             host.set_privilege_escalation_command(self.privilege_escalation_command.clone());
             host.set_extra_ssh_options(self.extra_ssh_options.clone());
 

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -228,38 +228,6 @@ impl NixFlags {
     pub fn has_option(&self, name: &str) -> bool {
         self.options.contains_key(name)
     }
-
-    /// Returns arguments for `nix-store`.
-    pub fn to_nix_store_args(&self) -> Vec<String> {
-        self.to_args_inner(true)
-    }
-
-    fn to_args_inner(&self, nix_store: bool) -> Vec<String> {
-        let mut args = Vec::new();
-
-        if self.show_trace {
-            args.push("--show-trace".to_string());
-        }
-
-        if self.pure_eval {
-            args.push("--pure-eval".to_string());
-        }
-
-        // The `nix-store` command does not accept `--impure`
-        // TODO: Not happy about this solution - Have a better Nix abstraction that hides
-        // CLI details (e.g., nix3 CLI differences)
-        if self.impure && !nix_store {
-            args.push("--impure".to_string());
-        }
-
-        for (name, value) in self.options.iter() {
-            args.push("--option".to_string());
-            args.push(name.to_string());
-            args.push(value.to_string());
-        }
-
-        args
-    }
 }
 
 fn validate_keys(keys: &HashMap<String, Key>) -> Result<(), ValidationErrorType> {

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -12,6 +12,7 @@ use crate::error::{ColmenaError, ColmenaResult};
 // TODO: Remove the allow once call sites are ported (following commits)
 #[allow(dead_code)]
 pub mod command;
+pub use command::NixCommand;
 
 pub mod host;
 use host::Ssh;
@@ -220,22 +221,12 @@ impl NixFlags {
         };
     }
 
-    pub fn set_options(&mut self, options: HashMap<String, String>) {
-        self.options = options.into_iter().collect();
-    }
-
-    // TODO: Remove the allow once call sites are ported (following commits)
-    #[allow(dead_code)]
     pub fn add_option(&mut self, name: String, value: String) {
         self.options.insert(name, value);
     }
 
     pub fn has_option(&self, name: &str) -> bool {
         self.options.contains_key(name)
-    }
-
-    pub fn to_args(&self) -> Vec<String> {
-        self.to_args_inner(false)
     }
 
     /// Returns arguments for `nix-store`.

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 use std::ops::Deref;
 use std::path::Path;
@@ -8,6 +8,10 @@ use serde::{Deserialize, Deserializer, Serialize};
 use validator::{Validate, ValidationError as ValidationErrorType};
 
 use crate::error::{ColmenaError, ColmenaResult};
+
+// TODO: Remove the allow once call sites are ported (following commits)
+#[allow(dead_code)]
+pub mod command;
 
 pub mod host;
 use host::Ssh;
@@ -106,17 +110,10 @@ pub struct NixFlags {
     /// Whether to pass --impure.
     impure: bool,
 
-    /// Designated builders.
-    ///
-    /// See <https://nixos.org/manual/nix/stable/advanced-topics/distributed-builds.html>.
-    ///
-    /// Valid examples:
-    /// - `@/path/to/machines`
-    /// - `builder@host.tld riscv64-linux /home/nix/.ssh/keys/builder.key 8 1 kvm`
-    builders: Option<String>,
-
     /// Options to pass as --option name value.
-    options: HashMap<String, String>,
+    ///
+    /// A BTreeMap is used so the options are emitted deterministically.
+    options: BTreeMap<String, String>,
 }
 
 impl NodeName {
@@ -209,12 +206,32 @@ impl NixFlags {
         self.impure = impure;
     }
 
+    /// Sets the designated builders, a plain `--option builders` value.
+    ///
+    /// See <https://nixos.org/manual/nix/stable/advanced-topics/distributed-builds.html>.
+    ///
+    /// Valid examples:
+    /// - `@/path/to/machines`
+    /// - `builder@host.tld riscv64-linux /home/nix/.ssh/keys/builder.key 8 1 kvm`
     pub fn set_builders(&mut self, builders: Option<String>) {
-        self.builders = builders;
+        match builders {
+            Some(builders) => self.options.insert("builders".to_string(), builders),
+            None => self.options.remove("builders"),
+        };
     }
 
     pub fn set_options(&mut self, options: HashMap<String, String>) {
-        self.options = options;
+        self.options = options.into_iter().collect();
+    }
+
+    // TODO: Remove the allow once call sites are ported (following commits)
+    #[allow(dead_code)]
+    pub fn add_option(&mut self, name: String, value: String) {
+        self.options.insert(name, value);
+    }
+
+    pub fn has_option(&self, name: &str) -> bool {
+        self.options.contains_key(name)
     }
 
     pub fn to_args(&self) -> Vec<String> {
@@ -228,14 +245,6 @@ impl NixFlags {
 
     fn to_args_inner(&self, nix_store: bool) -> Vec<String> {
         let mut args = Vec::new();
-
-        if let Some(builders) = &self.builders {
-            args.append(&mut vec![
-                "--option".to_string(),
-                "builders".to_string(),
-                builders.clone(),
-            ]);
-        }
 
         if self.show_trace {
             args.push("--show-trace".to_string());

--- a/src/nix/profile.rs
+++ b/src/nix/profile.rs
@@ -2,9 +2,10 @@ use std::convert::TryFrom;
 use std::path::Path;
 use std::process::Stdio;
 
-use tokio::process::Command;
-
-use super::{BuildResult, ColmenaError, ColmenaResult, Goal, StoreDerivation, StorePath};
+use super::{
+    BuildResult, ColmenaError, ColmenaResult, Goal, NixCommand, NixFlags, SYSTEM_PROFILE,
+    StoreDerivation, StorePath,
+};
 
 pub type ProfileDerivation = StoreDerivation<Profile>;
 
@@ -23,6 +24,14 @@ impl Profile {
         } else {
             Ok(Self(path))
         }
+    }
+
+    /// Returns the command to switch the system profile to this profile,
+    /// shared by the local and remote activation paths.
+    pub fn switch_profile_command(&self, flags: &NixFlags) -> NixCommand {
+        NixCommand::nix_env(flags.clone())
+            .args(["--profile", SYSTEM_PROFILE, "--set"])
+            .arg(self.as_path())
     }
 
     /// Returns the command to activate this profile.
@@ -51,15 +60,13 @@ impl Profile {
     }
 
     /// Create a GC root for this profile.
-    pub async fn create_gc_root(&self, path: &Path) -> ColmenaResult<()> {
-        let mut command = Command::new("nix-store");
-        command.args([
-            "--no-build-output",
-            "--indirect",
-            "--add-root",
-            path.to_str().unwrap(),
-        ]);
-        command.args(["--realise", self.as_path().to_str().unwrap()]);
+    pub async fn create_gc_root(&self, path: &Path, flags: &NixFlags) -> ColmenaResult<()> {
+        let mut command = NixCommand::nix_store(flags.clone())
+            .args(["--no-build-output", "--indirect", "--add-root"])
+            .arg(path)
+            .arg("--realise")
+            .arg(self.as_path())
+            .build();
         command.stdout(Stdio::null());
 
         let status = command.status().await?;

--- a/src/nix/store.rs
+++ b/src/nix/store.rs
@@ -5,11 +5,9 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use tokio::process::Command;
 
-use super::Host;
+use super::{Host, NixCommand, NixFlags};
 use crate::error::{ColmenaError, ColmenaResult};
-use crate::util::CommandExt;
 
 /// A Nix store path.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -43,19 +41,12 @@ impl StorePath {
         }
     }
 
-    /// Returns the immediate dependencies of the store path.
-    pub async fn references(&self) -> ColmenaResult<Vec<StorePath>> {
-        let references = Command::new("nix-store")
-            .args(["--query", "--references"])
-            .arg(&self.0)
-            .capture_output()
-            .await?
-            .trim_end()
-            .split('\n')
-            .map(|p| StorePath(PathBuf::from(p)))
-            .collect();
-
-        Ok(references)
+    /// Returns a command realising the store path, shared by the
+    /// local and remote build paths.
+    pub fn realise_command(&self, flags: &NixFlags) -> NixCommand {
+        NixCommand::nix_store(flags.clone())
+            .args(["--no-gc-warning", "--realise"])
+            .arg(self.as_path())
     }
 
     /// Converts the store path into a store derivation.

--- a/src/troubleshooter.rs
+++ b/src/troubleshooter.rs
@@ -7,10 +7,10 @@ use std::future::Future;
 
 use snafu::ErrorCompat;
 
-use crate::{error::ColmenaError, nix::HivePath};
+use crate::error::ColmenaError;
 
 /// Runs a closure and tries to troubleshoot if it returns an error.
-pub async fn run_wrapped<F, T>(f: F, hive_config: Option<HivePath>) -> T
+pub async fn run_wrapped<F, T>(f: F) -> T
 where
     F: Future<Output = Result<T, ColmenaError>>,
 {
@@ -20,7 +20,7 @@ where
             tracing::error!("-----");
             tracing::error!("Operation failed with error: {}", error);
 
-            if let Err(own_error) = troubleshoot(hive_config, &error) {
+            if let Err(own_error) = troubleshoot(&error) {
                 tracing::error!(
                     "Error occurred while trying to troubleshoot another error: {}",
                     own_error
@@ -33,25 +33,7 @@ where
     }
 }
 
-fn troubleshoot(hive_config: Option<HivePath>, error: &ColmenaError) -> Result<(), ColmenaError> {
-    if let ColmenaError::NoFlakesSupport = error {
-        // People following the tutorial might put hive.nix directly
-        // in their Colmena checkout, and encounter NoFlakesSupport
-        // because Colmena always prefers flake.nix when it exists.
-
-        if hive_config.is_none() {
-            let cwd = env::current_dir()?;
-            if cwd.join("flake.nix").is_file() && cwd.join("hive.nix").is_file() {
-                eprintln!(
-                    "Hint: You have both flake.nix and hive.nix in the current directory, and"
-                );
-                eprintln!("      Colmena will always prefer flake.nix if it exists.");
-                eprintln!();
-                eprintln!("      Try passing `-f hive.nix` explicitly if this is what you want.");
-            }
-        };
-    }
-
+fn troubleshoot(error: &ColmenaError) -> Result<(), ColmenaError> {
     if let Some(bt) = ErrorCompat::backtrace(error) {
         if backtrace_enabled() {
             eprintln!("Backtrace:");


### PR DESCRIPTION
closes https://github.com/nix-community/colmena/issues/346

there are multiple references to nix 2.4 and 2.10 where on repology https://repology.org/project/nix/badges major distro package manager are far beyond 2.10 (which is released https://github.com/NixOS/nix/tags?after=2.11.0 more than 4 years ago)
